### PR TITLE
static ファイルへのアクセスを簡便化

### DIFF
--- a/layouts/partials/head-additions.html
+++ b/layouts/partials/head-additions.html
@@ -9,3 +9,5 @@
 {{ range .Params.custom_js }}
 <script src="{{ . | relURL }}"></script>
 {{ end }}
+
+<base href="{{ .Site.BaseURL }}">


### PR DESCRIPTION
# 概要
`/static` 下にあるファイルについて，マークダウンから`![image/center.png](センターの写真)` のようにアクセスできるよう，修正しました．

# 詳細
`head` タグのなかに `base` タグを設置し，`baseURL` を指定しました．